### PR TITLE
feat(gitignore): ✨ add new .gitignore templates

### DIFF
--- a/packages/core/src/templates/gitignore/android.tpl
+++ b/packages/core/src/templates/gitignore/android.tpl
@@ -1,0 +1,29 @@
+# Build Artifacts
+/build/
+/.gradle/
+*.apk
+*.aab
+*.aar
+local.properties
+
+# Keystore Files
+*.jks
+*.keystore
+
+# Logs
+*.log
+
+# IDEs and Common Tools
+.idea/
+*.iml
+captures/
+crashlytics/
+
+# Temporary Files
+/tmp/
+*~
+*.swp
+
+# OS Files
+.DS_Store
+Thumbs.db

--- a/packages/core/src/templates/gitignore/angular.tpl
+++ b/packages/core/src/templates/gitignore/angular.tpl
@@ -1,0 +1,31 @@
+# Node.js and Package Managers
+node_modules/
+npm-debug.log
+yarn-error.log
+.pnp.cjs
+.pnp.loader.cjs
+
+# Build Artifacts
+/dist/
+/out-tsc/
+
+# Cache and Logs
+.angular/cache/
+*.log
+*.tsbuildinfo
+.eslintcache
+
+# Coverage Reports
+/coverage/
+
+# IDEs and Common Tools
+.DS_Store
+.idea/
+.vscode/
+Thumbs.db
+
+# Temporary Files
+/tmp/
+*.bak
+*.swp
+*~

--- a/packages/core/src/templates/gitignore/flutter.tpl
+++ b/packages/core/src/templates/gitignore/flutter.tpl
@@ -1,0 +1,39 @@
+# Build Artifacts
+/build/
+.dart_tool/
+.flutter-plugins-dependencies
+.flutter-plugins-lock
+
+# Logs
+*.log
+
+# IDEs and Common Tools
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db
+
+# Android Specific
+android/build/
+android/.gradle/
+android/local.properties
+android/app/*.iml
+*.jks
+*.keystore
+
+# iOS Specific
+ios/build/
+ios/.symlinks/
+ios/DerivedData/
+ios/*.xcodeproj/xcuserdata/
+ios/*.xcodeproj/project.xcworkspace/xcuserdata/
+ios/*.xcarchive/
+ios/Pods/
+
+# Temporary Files
+*~
+*.swp
+*.bak
+
+# Flutter specific
+flutter_plugin_annotations/

--- a/packages/core/src/templates/gitignore/go.tpl
+++ b/packages/core/src/templates/gitignore/go.tpl
@@ -1,0 +1,26 @@
+# Go Specific
+*.exe
+*.bin
+*.test
+*.out
+/bin/
+/build/
+
+# Dependencies
+/vendor/
+
+# Logs
+*.log
+
+# IDEs and Common Tools
+.DS_Store
+.idea/
+.vscode/
+Thumbs.db
+
+# Temporary Files
+/tmp/
+/pkg/
+
+# Environment variables
+.env

--- a/packages/core/src/templates/gitignore/ides.tpl
+++ b/packages/core/src/templates/gitignore/ides.tpl
@@ -1,0 +1,25 @@
+# VS Code
+/.vscode/
+/.vscode/*
+
+# macOS
+.DS_Store
+.localized
+.Spotlight-V100
+.Trashes
+._*
+.AppleDouble
+.AppleDB
+.TemporaryItems
+ehthumbs.db
+Desktop.ini
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+*.lnk
+$RECYCLE.BIN/
+System Volume Information/
+pagefile.sys
+hiberfil.sys

--- a/packages/core/src/templates/gitignore/java.tpl
+++ b/packages/core/src/templates/gitignore/java.tpl
@@ -1,0 +1,35 @@
+# Build Artifacts
+/target/
+/build/
+.gradle/
+*.jar
+*.war
+*.ear
+*.zip
+*.tar
+*.tar.gz
+*.class
+
+# Logs
+*.log
+/logs/
+
+# IDEs and Common Tools
+.idea/
+*.iml
+.class
+.project
+.settings/
+.vscode/
+
+# OS Files
+.DS_Store
+Thumbs.db
+
+# Temporary Files
+/tmp/
+*~
+*.swp
+
+# Environment variables
+.env

--- a/packages/core/src/templates/gitignore/javascript.tpl
+++ b/packages/core/src/templates/gitignore/javascript.tpl
@@ -1,0 +1,39 @@
+# Node.js and Package Managers
+node_modules/
+npm-debug.log
+yarn-error.log
+.pnp.cjs
+.pnp.loader.cjs
+
+# Build Artifacts
+/dist/
+/out-tsc/
+
+# Cache and Logs
+.angular/cache/ # Applies to Angular, but common for JS caches
+*.log
+*.tsbuildinfo
+.eslintcache
+.cache/
+/tmp/
+
+# Coverage Reports
+/coverage/
+
+# Environment variables
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env.*.local
+
+# IDEs and Common Tools
+.DS_Store
+.idea/
+.vscode/
+Thumbs.db
+
+# Temporary Files
+*.bak
+*.swp
+*~

--- a/packages/core/src/templates/gitignore/php.tpl
+++ b/packages/core/src/templates/gitignore/php.tpl
@@ -1,0 +1,40 @@
+# Dependencies
+/vendor/
+
+# Logs
+*.log
+/logs/
+
+# Cache and Temporary Files
+/cache/
+/tmp/
+/var/cache/
+/var/tmp/
+/var/log/
+/var/sessions/
+/storage/framework/cache/
+/storage/framework/sessions/
+/storage/framework/views/
+
+# Uploads and Public Assets
+/public/uploads/
+/storage/app/public/
+
+# Environment variables
+.env
+.env.*.local
+
+# Build Artifacts
+*.phar
+/public/build/
+/web/assets/
+
+# IDEs and Common Tools
+.DS_Store
+.idea/
+.vscode/
+Thumbs.db
+
+# Temporary Files
+*~
+*.swp

--- a/packages/core/src/templates/gitignore/python.tpl
+++ b/packages/core/src/templates/gitignore/python.tpl
@@ -1,0 +1,68 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Build artifacts
+dist/
+build/
+
+# Environment variables
+.env
+.env.local
+
+# Python Specific
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual Environment
+env/
+venv/
+VIRTUALENV/
+.virtualenv/
+.venv/
+pip-log.txt
+.python
+
+# Build/Distribution Files
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Test Files and Coverage
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# IDEs and Common Tools
+.idea/
+*.iml
+.vscode/
+.mypy_cache/
+.ruff_cache/
+
+# Frameworks (General Python/Django/Flask related)
+*.log
+*.sqlite3
+media/
+static.root/
+/static/
+instance/
+
+.ipynb_checkpoints/
+
+.env
+.flaskenv
+
+# OS Files
+.DS_Store
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Temporary and Cache Files
+/tmp/

--- a/packages/core/src/templates/gitignore/react.tpl
+++ b/packages/core/src/templates/gitignore/react.tpl
@@ -1,0 +1,32 @@
+# Node.js and Package Managers
+node_modules/
+npm-debug.log
+yarn-error.log
+.pnp.cjs
+.pnp.loader.cjs
+
+# Build Artifacts
+/build/
+/dist/
+
+# Coverage Reports
+/coverage/
+*.log
+
+# Environment variables
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env.*.local
+
+# Cache and Temporary Files
+.cache/
+/tmp/
+*.eslintcache
+
+# IDEs and Common Tools
+.DS_Store
+.idea/
+.vscode/
+Thumbs.db

--- a/packages/core/src/templates/gitignore/react_native.tpl
+++ b/packages/core/src/templates/gitignore/react_native.tpl
@@ -1,0 +1,62 @@
+# Node.js and Package Managers
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp.cjs
+.pnp.loader.cjs
+
+# Build/Cache files
+*.js.map
+*.d.ts.map
+*.tsbuildinfo
+.eslintcache
+.cache/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env.*.local
+
+# Android Specific
+android/build/
+android/.gradle/
+android/*.apk
+android/*.aab
+android/*.aar
+android/local.properties
+*.jks
+*.keystore
+
+# iOS Specific
+ios/build/
+ios/DerivedData/
+ios/*.xcarchive/
+ios/*.ipa
+ios/*.app
+ios/*.dSYM
+ios/Pods/
+ios/.build/
+ios/*.xcodeproj/xcuserdata/
+ios/*.xcodeproj/project.xcworkspace/xcuserdata/
+
+# Coverage Reports
+/coverage/
+
+# IDEs and Common Tools
+.idea/
+.vscode/
+
+# Logs and Temporary Files
+*.log
+/tmp/
+
+# OS Files
+.DS_Store
+Thumbs.db
+*~
+*.swp
+*.bak

--- a/packages/core/src/templates/gitignore/svelte.tpl
+++ b/packages/core/src/templates/gitignore/svelte.tpl
@@ -1,0 +1,36 @@
+# Node.js and Package Managers
+node_modules/
+npm-debug.log
+yarn-error.log
+.pnp.cjs
+.pnp.loader.cjs
+
+# Build Artifacts
+.svelte-kit/
+/build/
+/package/
+
+# Cache and Logs
+.eslintcache
+*.log
+.turbo/
+/tmp/
+*.bak
+*.swp
+*~
+
+# Coverage Reports
+/coverage/
+
+# Environment variables
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env.*.local
+
+# IDEs and Common Tools
+.DS_Store
+.idea/
+.vscode/
+Thumbs.db

--- a/packages/core/src/templates/gitignore/swift.tpl
+++ b/packages/core/src/templates/gitignore/swift.tpl
@@ -1,0 +1,31 @@
+# Build Artifacts
+/build/
+/DerivedData/
+*.xcarchive/
+*.ipa
+*.app
+*.dSYM
+
+# Xcode User Data
+*.xcodeproj/xcuserdata/
+*.xcodeproj/project.xcworkspace/xcuserdata/
+
+# Dependencies
+/Pods/
+/.build/
+*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
+
+# Logs
+*.log
+
+# Playgrounds
+*.playground/xcuserdata/
+*.playground/DerivedData/
+
+# OS Files
+.DS_Store
+
+# Temporary Files
+*~
+*.swp
+*.bak

--- a/packages/core/src/templates/gitignore/vue.tpl
+++ b/packages/core/src/templates/gitignore/vue.tpl
@@ -1,0 +1,39 @@
+# Node.js and Package Managers
+node_modules/
+npm-debug.log
+yarn-error.log
+.pnp.cjs
+.pnp.loader.cjs
+
+# Build Artifacts
+/dist/
+
+# Coverage Reports
+/coverage/
+*.log
+
+# Cache and Temporary Files
+.eslintcache
+*.tsbuildinfo
+/tmp/
+.cache/
+*.bak
+*.swp
+*~
+
+# Environment variables
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.env.*.local
+
+# IDEs and Common Tools
+.DS_Store
+.idea/
+.vscode/
+Thumbs.db
+
+# Vue-specific
+.vuepress/temp/
+.vuepress/cache/


### PR DESCRIPTION
### Sumário

Este PR expande a funcionalidade do comando `stc generate gitignore` através da adição de novos templates, permitindo que a ferramenta gere arquivos `.gitignore` para uma maior variedade de tecnologias.

### Mudanças

- Adicionados novos arquivos de template (`.tpl`) ao diretório `packages/core/src/templates/gitignore` para suportar novas stacks de projeto.

### Como Testar

1.  Após obter esta branch, execute `npm run build`.
2.  Em um diretório de teste, execute o comando `stc generate gitignore <novo_tipo>`, substituindo `<novo_tipo>` por uma das tecnologias dos templates adicionados.
3.  Verifique se o arquivo `.gitignore` gerado corresponde ao conteúdo do template apropriado.